### PR TITLE
Due to how the client obtains the address for the server, using a pot…

### DIFF
--- a/charts/forseti-security/templates/server/service.yaml
+++ b/charts/forseti-security/templates/server/service.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-server
+  name: forseti-server
 {{- if and (eq .Values.loadBalancer "internal") (.Values.production) }}
   annotations:
     cloud.google.com/load-balancer-type: "Internal"


### PR DESCRIPTION
…entially conflicting name is necessary in the short term

Signed-off-by: Ken Evensen <kdevensen@google.com>