### PR TITLE
Adding a destination for git-sync

### DIFF
--- a/charts/forseti-security/templates/config-validator/_pod-spec.yaml
+++ b/charts/forseti-security/templates/config-validator/_pod-spec.yaml
@@ -18,6 +18,7 @@ initContainers:
   args:
   - -repo={{ .Values.policyLibraryRepositoryURL }}
   - -branch={{ .Values.policyLibraryRepositoryBranch }}
+  - -dest=policy-library
   - -one-time
   - -ssh={{ .Values.gitSyncSSH }}
   - -ssh-known-hosts=false
@@ -38,6 +39,7 @@ containers:
   args:
   - -repo={{ .Values.policyLibraryRepositoryURL }}
   - -branch={{ .Values.policyLibraryRepositoryBranch }}
+  - -dest=policy-library
   - -wait={{ .Values.gitSyncWait }}
   - -webhook-url=http://localhost:8001/api/v1/namespaces/{{ .Release.Namespace }}/pods/$(POD_NAME)
   - -webhook-method=DELETE


### PR DESCRIPTION
This is to handle the case where a user's policy-library git repository may not be named "policy-library"