### PR TITLE
Add support for custom Cloud SQL DB name

### DIFF
--- a/charts/forseti-security/README.md
+++ b/charts/forseti-security/README.md
@@ -129,13 +129,14 @@ helm install forseti-security/forseti-security \
     --set production=true
     --set-string serverConfigContents="$(gsutil cat gs://<BUCKET_NAME>/configs/forseti_conf_server.yaml | base64 -)" \
     --values forseti-values.yaml
-    
+
 ```
 
 | Parameter                                | Description                                    | Default|
 | ----------------------------- | ------------------------------------ |------------------------------------------- |
-| **server.cloudsqlConnection**        | This is the connection to the CloudSQL instance.          | `nil`|
 | configValidator.enabled               | This sets whether or not to deploy config-validator       | `false` |
+| **database.connectionName**        | This is the connection to the CloudSQL instance.          | `nil`|
+| database.name        | This is the name of the CloudSQL database.          | `forseti_security`|
 | networkPolicy.enabled           | Enable pod network policy to limit the connectivty to the server. | `false` |
 | networkPolicy.ingressCidr      | A list of CIDR's from which to allow communication to the server.  This is only relevant for client connectivity from outside the Kubernetes cluster. | `[]` |
 | nodeSelectors                 | A list of strings in the form of label=value describing on which nodes to run the Forseti on-GKE pods. | `nil` |

--- a/charts/forseti-security/templates/NOTES.txt
+++ b/charts/forseti-security/templates/NOTES.txt
@@ -1,15 +1,15 @@
-{{- if and (not .Values.server.cloudsqlConnection) (.Values.production) }}
+{{- if and (not .Values.database.connectionName) (.Values.production) }}
 
-It looks like you are missing information for the Forseti CloudSQL 
+It looks like you are missing information for the Forseti CloudSQL
 instance.  Please provide the following:
-    
-   server.cloudsqlConnection - A CloudSQL connection string in the form 
+
+   database.connectionName - A CloudSQL connection string in the form
                               of \"project:location:cloud-sql-instance-name\"
 {{- end -}}
 
 {{- if and (not .Values.server.config.bucket) (.Values.production) }}
 
-It looks like you are missing the name of the GCS bucket holding the 
+It looks like you are missing the name of the GCS bucket holding the
 server configuration.  Please provide the following:
 
     server.config.bucket - The bucket containing the server configurations.
@@ -18,22 +18,22 @@ server configuration.  Please provide the following:
 
 {{- if and (not .Values.server.config.contents) (.Values.production) }}
 
-It looks like you are missing the contents of the Forseti server configuration file, usually 
+It looks like you are missing the contents of the Forseti server configuration file, usually
 found in <PATH>/forseti_conf_server.yaml.
 
-    1. If the server configuration file is local to the machine executing Helm add 
+    1. If the server configuration file is local to the machine executing Helm add
        the following parameter to your helm command:
 
-        --set-string server.config.contents="$(cat <PATH>/forseti_conf_server.yaml | base64 -)" 
+        --set-string server.config.contents="$(cat <PATH>/forseti_conf_server.yaml | base64 -)"
 
     2. If the server configuration is in a GCS bucket, then use the following (assumes
        gsutil is present on host executing helm):
 
        --set-string server.config.contents="$(gsutil cat gs://<BUCKET_NAME>/<CONFIGS_FOLDER>/forseti_conf_server.yaml | base64 -)"
-    
+
     Run Helm upgrade or install feeding in the base64 encoded contents of the key file:
 
-        
+
 
 {{- end -}}
 
@@ -54,4 +54,3 @@ Thank you for installing {{ .Chart.Name }}.
 Your release is named {{ .Release.Name }}.
 
 Please visit https://forsetisecurity.org for information on configuring Forseti.
-

--- a/charts/forseti-security/templates/server/pod/_cloudsqlproxy-container.yaml
+++ b/charts/forseti-security/templates/server/pod/_cloudsqlproxy-container.yaml
@@ -17,8 +17,8 @@
   image: gcr.io/cloudsql-docker/gce-proxy:latest
   command: ["/cloud_sql_proxy"]
   args:
-  - -instances={{ .Values.server.cloudsqlConnection }}=tcp:3306
+  - -instances={{ .Values.database.connectionName }}=tcp:3306
   securityContext:
-    runAsUser: 2 
+    runAsUser: 2
     allowPrivilegeEscalation: false
 {{ end -}}

--- a/charts/forseti-security/templates/server/pod/_server-container.yaml
+++ b/charts/forseti-security/templates/server/pod/_server-container.yaml
@@ -28,7 +28,7 @@
   - {{ .Release.Name }}-server.{{ .Release.Namespace }}.svc.cluster.local
 {{- end }}
   - --sql_database_name
-  -  {{ .Values.server.cloudsqlDatabaseName }}
+  -  {{ .Values.database.name }}
   - --log_level
   -  {{ .Values.server.logLevel | default "debug" }}
   - --server_host

--- a/charts/forseti-security/templates/server/pod/_server-container.yaml
+++ b/charts/forseti-security/templates/server/pod/_server-container.yaml
@@ -27,6 +27,8 @@
   - --sql_host
   - {{ .Release.Name }}-server.{{ .Release.Namespace }}.svc.cluster.local
 {{- end }}
+  - --sql_database_name
+  -  {{ .Values.server.cloudsqlDatabaseName }}
   - --log_level
   -  {{ .Values.server.logLevel | default "debug" }}
   - --server_host

--- a/charts/forseti-security/templates/server/pod/_sql-container.yaml
+++ b/charts/forseti-security/templates/server/pod/_sql-container.yaml
@@ -23,7 +23,7 @@
   - name: MYSQL_ALLOW_EMPTY_PASSWORD
     value: "1"
   - name: MYSQL_DATABASE
-    value: {{ .Values.server.cloudsqlDatabaseName }}
+    value: {{ .Values.database.name }}
   ports:
   - containerPort: 3306
   volumeMounts:

--- a/charts/forseti-security/templates/server/pod/_sql-container.yaml
+++ b/charts/forseti-security/templates/server/pod/_sql-container.yaml
@@ -23,7 +23,7 @@
   - name: MYSQL_ALLOW_EMPTY_PASSWORD
     value: "1"
   - name: MYSQL_DATABASE
-    value: forseti_security
+    value: {{ .Values.server.cloudsqlDatabaseName }}
   ports:
   - containerPort: 3306
   volumeMounts:

--- a/charts/forseti-security/values.yaml
+++ b/charts/forseti-security/values.yaml
@@ -15,12 +15,6 @@
 
 ## forseti-server ##
 server:
-  # server.cloudsqlConnection is the connection to the cloudsql instance
-  cloudsqlConnection: ""
-
-  # cloudsqlDatabaseName is the name of the Forseti Cloud SQL database
-  cloudsqlDatabaseName: forseti_security
-
   # server.cloudProfilerEnabled enables the forseti-server to send metrics to Cloud Profiler
   cloudProfilerEnabled: false
 
@@ -58,6 +52,15 @@ server:
   # server.workloadIdentity is the GCP IAM Service account for the Forseti server.
   # Setting this assumes that the workload identity is configured for the GKE cluster.
   workloadIdentity: ""
+
+
+## forseti-database ##
+database:
+  # database.connectionName is the connection to the cloudsql instance
+  connectionName: ""
+
+  # database.name is the name of the Forseti Cloud SQL database
+  name: forseti_security
 
 
 ## forseti-orchestrator ##

--- a/charts/forseti-security/values.yaml
+++ b/charts/forseti-security/values.yaml
@@ -18,6 +18,9 @@ server:
   # server.cloudsqlConnection is the connection to the cloudsql instance
   cloudsqlConnection: ""
 
+  # cloudsqlDatabaseName is the name of the Forseti Cloud SQL database
+  cloudsqlDatabaseName: forseti_security
+
   # server.cloudProfilerEnabled enables the forseti-server to send metrics to Cloud Profiler
   cloudProfilerEnabled: false
 
@@ -30,7 +33,6 @@ server:
 
     # server.contents is the Base64 encoded contents of the forseti_conf_server.yaml file.
     contents: ""
-
 
   # server.loadBalancer is the type of load balancer to deploy for the
   # forseti-server if desired: none, external, internal


### PR DESCRIPTION
Added the Cloud SQL db name as a value and using that for the Forseti server along with the SQL container used for testing. This change is to support the GKE/Helm component of the Forseti issue https://github.com/forseti-security/forseti-security/issues/2938.