### PR TITLE
adding kube proxy image tag

### DIFF
--- a/charts/config-validator/templates/pod/_kube-proxy.yaml
+++ b/charts/config-validator/templates/pod/_kube-proxy.yaml
@@ -14,7 +14,6 @@
 
 {{- define "spec.container.kubeProxy" }}
 - name: kube-proxy
-  image: mirror.gcr.io/bitnami/kubectl:latest
   image: "{{ .Values.policyLibrary.gitSync.kubeProxyImage }}:{{ .Values.policyLibrary.gitSync.kubeProxyImageTag }}"
   args:
   - proxy

--- a/charts/config-validator/templates/pod/_kube-proxy.yaml
+++ b/charts/config-validator/templates/pod/_kube-proxy.yaml
@@ -15,6 +15,7 @@
 {{- define "spec.container.kubeProxy" }}
 - name: kube-proxy
   image: mirror.gcr.io/bitnami/kubectl:latest
+  image: "{{ .Values.policyLibrary.gitSync.kubeProxyImage }}:{{ .Values.policyLibrary.gitSync.kubeProxyImageTag }}"
   args:
   - proxy
   - --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt

--- a/charts/config-validator/values.yaml
+++ b/charts/config-validator/values.yaml
@@ -59,6 +59,12 @@ policyLibrary:
     # policyLibrary.gitSync.imageTag is the container image tag used by the config-validator git-sync side-car
     imageTag: v3.1.2
 
+    # policyLibrary.gitSync.kubeProxyImage is the container image used by the config-validator's kube-proxy sidecar to periodically delete the git-sync pod
+    kubeProxyImage: docker.io/bitnami/kubectl
+
+    # policyLibrary.gitSync.kubeProxyImageTag is the container image tag used by the config-validator's kube-proxy sidecar to periodically delete the git-sync pod
+    kubeProxyImageTag: "1.15"
+
     # policyLibrary.gitSync.privateSSHKey is the private OpenSSH key generated to allow the git-sync to clone the policy library repository over SSH.
     # Omitting this value will sync the policy-library over HTTPS.
     privateSSHKey: ""


### PR DESCRIPTION
while attempting to run this chart on gke 1.15 the kube-proxy container image errors out with:
`"error: default cluster has no server defined"`

by matching the kube-proxy image tag to the one running in our gke environment (`GitVersion:"v1.15.9-gke.24"`) I was able to get this running.